### PR TITLE
Fixed Spark 2.4.0 to 2.4.3, 2.4.0 not available anymore.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1063,15 +1063,15 @@
         </property>
       </activation>
       <properties>
-        <spark.scala-2.11.version>2.4.0</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.3</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.11.version>4.1.17.Final</netty.spark-2.11.version>
         <java.version>1.8</java.version>
         <py4j.version>0.10.7</py4j.version>
         <spark.bin.download.url>
-          http://mirrors.advancedhosters.com/apache/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz
+          http://mirrors.advancedhosters.com/apache/spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz
         </spark.bin.download.url>
-        <spark.bin.name>spark-2.4.0-bin-hadoop2.7</spark.bin.name>
+        <spark.bin.name>spark-2.4.3-bin-hadoop2.7</spark.bin.name>
       </properties>
     </profile>
 


### PR DESCRIPTION
Signed-off-by: Aliaksandr Sasnouskikh <jahstreetlove@gmail.com>

Fixed Spark 2.4.0 to 2.4.3, 2.4.0 not available anymore.