### PR TITLE
Create SparkApp on InteractiveSession recovery even if client.driverProcess is not defined

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -401,7 +401,12 @@ class InteractiveSession(
     app = mockApp.orElse {
       val driverProcess = client.flatMap { c => Option(c.getDriverProcess) }
         .map(new LineBufferedProcess(_, livyConf.getInt(LivyConf.SPARK_LOGS_SIZE)))
-      driverProcess.map { _ => SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)) }
+      if (!livyConf.isRunningOnKubernetes()){
+        driverProcess.map(_ => SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)))
+      } else {
+        // Create SparkApp for Kubernetes anyway
+        Some(SparkApp.create(appTag, appId, driverProcess, livyConf, Some(this)))
+      }
     }
 
     if (client.isEmpty) {


### PR DESCRIPTION
Create SparkApp on InteractiveSession recovery even if client.driverProcess is not defined

Signed-off-by: Aliaksandr Sasnouskikh <jahstreetlove@gmail.com>