### PR TITLE
Update Kubernetes client version 5.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <py4j.version>0.10.7</py4j.version>
     <scala-2.11.version>2.11.12</scala-2.11.version>
-    <scala-2.12.version>2.12.10</scala-2.12.version>
+    <scala-2.12.version>2.12.15</scala-2.12.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>${scala-2.11.version}</scala.version>
     <scalatest.version>3.0.8</scalatest.version>
@@ -651,7 +651,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>4.2.0</version>
+          <version>4.4.0</version>
           <executions>
             <execution>
               <goals>
@@ -1088,7 +1088,7 @@
           https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
         </spark.bin.download.url>
         <spark.bin.name>spark-3.0.0-bin-hadoop2.7</spark.bin.name>
-        <kubernetes.client.version>4.9.2</kubernetes.client.version>
+        <kubernetes.client.version>5.12.2</kubernetes.client.version>
         <jackson.version>2.10.3</jackson.version>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
     <spark.scala-2.12.version>2.4.5</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
-    <kubernetes.client.version>4.6.4</kubernetes.client.version>
+    <kubernetes.client.version>5.12.2</kubernetes.client.version>
     <hive.version>3.0.0</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>

--- a/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
@@ -18,8 +18,8 @@ package org.apache.livy.utils
 
 import java.util.Objects._
 
-import io.fabric8.kubernetes.api.model._
-import io.fabric8.kubernetes.api.model.extensions.{Ingress, IngressRule, IngressSpec}
+import io.fabric8.kubernetes.api.model.{Pod, Service, HasMetadata, ServiceBuilder, OwnerReferenceBuilder, PodStatus, ObjectMeta}
+import io.fabric8.kubernetes.api.model.networking.v1.{Ingress, IngressRule, IngressSpec}
 import org.mockito.Mockito.when
 import org.scalatest.FunSpec
 import org.scalatest.mock.MockitoSugar._


### PR DESCRIPTION
## What changes were proposed in this pull request?

On regular upgrade activity, recently we upgraded Kubernetes server version to 1.22 which includes client version as 5.12.2. But Kubernetes client version 4.6.4 is used in Livy.

On 5.12.2 version, Ingress API is changed which is not backward compatible.

With this change, we can use Livy on Kubernetes server 1.22

## How was this patch tested?

Manually tested this patch and deployed on Kubernetes server where Livy APIs are working as expected.
